### PR TITLE
Delete application node in manifest.

### DIFF
--- a/recycler-itemdecoration/src/main/AndroidManifest.xml
+++ b/recycler-itemdecoration/src/main/AndroidManifest.xml
@@ -1,8 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest
     package="com.github.magiepooh.recycleritemdecoration">
-
-    <application android:allowBackup="true" android:label="@string/app_name">
-
-    </application>
-
 </manifest>


### PR DESCRIPTION
Libraries should not define application node; allowBackup attribute may cause caller get a build error like following:
> Error:Execution failed for task ':app:processDebugManifest'.
> Manifest merger failed : Attribute application@allowBackup value=(false) from AndroidManifest.xml:77:9-36
  	is also present at [com.github.magiepooh:recycler-itemdecoration:1.1.1] AndroidManifest.xml:12:9-35 value=(true).
  	Suggestion: add 'tools:replace="android:allowBackup"' to <application> element at AndroidManifest.xml:75:5-520:19 to override.

Although we can add `tools:replace` as suggestion, but I think **libraries should not define this attribute at all**.