### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You don't need to think about items' position! You need to care about their **Vi
 
 # Gradle
 ```
-compile 'com.github.magiepooh:recycler-itemdecoration:1.1.1@aar'
+implementation 'com.github.magiepooh:recycler-itemdecoration:1.1.1@aar'
 ```
 
 # How To Use


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.